### PR TITLE
Navbar accents

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -213,6 +213,16 @@ body {
 	padding-right: 40px;
 }
 
+ul.navbar-nav > li:hover {
+	margin-bottom: -4px;
+	border-bottom: 4px solid #ccc;
+}
+
+ul.navbar-nav > li.hover-box-shadow:hover {
+	box-shadow: inset 0 0 10px #ccc;
+}
+
+
 .navbar.box-shadow {
 	/* -webkit-box-shadow: 0px 3px 5px 0px #ccc; */
 	/* -moz-box-shadow: 0px 3px 5px 0px #ccc; */

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -214,8 +214,8 @@ body {
 }
 
 ul.navbar-nav > li:hover {
-	margin-bottom: -4px;
-	border-bottom: 4px solid #ccc;
+	margin-bottom: -2px;
+	border-bottom: 2px solid #ccc;
 }
 
 ul.navbar-nav > li.hover-box-shadow:hover {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -219,6 +219,8 @@ ul.navbar-nav > li:hover {
 }
 
 ul.navbar-nav > li.hover-box-shadow:hover {
+	/* -webkit-box-shadow: inset 0 0 10px #ccc; */
+	/* -moz-box-shadow: inset 0 0 10px #ccc; */
 	box-shadow: inset 0 0 10px #ccc;
 }
 

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -213,6 +213,12 @@ body {
 	padding-right: 40px;
 }
 
+.navbar.box-shadow {
+	/* -webkit-box-shadow: 0px 3px 5px 0px #ccc; */
+	/* -moz-box-shadow: 0px 3px 5px 0px #ccc; */
+	box-shadow: 0px 2px 10px 0px #ccc;
+}
+
 .label-list.label-list-name {
 	display: inline-block;
 	font-size: 100%;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
 	</head>
 
 	<body>
-		<%= navbar fixed: :top do %>
+		<%= navbar fixed: :top, class: "box-shadow" do %>
 		<div class="row">
 			<div class="<%= current_user ? "col-md-10 col-md-offset-1" : "col-md-8 col-md-offset-2"%>">
 			<%= navbar_header brand: "Docket", brand_link: root_url%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,19 +22,19 @@
 			<div class="<%= current_user ? "col-md-10 col-md-offset-1" : "col-md-8 col-md-offset-2"%>">
 			<%= navbar_header brand: "Docket", brand_link: root_url%>
 			<%= navbar_group class: "foo", id: "menu" do %>
-				<%= navbar_item "Events", events_path %>
-				<%= navbar_item "Teachers", teachers_path %>
-				<%= navbar_item "Courses", courses_path %>
-				<%= navbar_item "Classes", classrooms_path %>
+				<%= navbar_item "Events", events_path, class: "hover-box-shadow" %>
+				<%= navbar_item "Teachers", teachers_path, class: "hover-box-shadow" %>
+				<%= navbar_item "Courses", courses_path, class: "hover-box-shadow" %>
+				<%= navbar_item "Classes", classrooms_path, class: "hover-box-shadow" %>
 			<% end %>
 			<%= navbar_group align: "right" do %>
 				<% if current_user %>
-					<%= navbar_item "My Account", edit_polymorphic_path(current_user) %>
+					<%= navbar_item "My Account", edit_polymorphic_path(current_user), class: "hover-box-shadow" %>
 					<%= navbar_text "Logged In as " + current_user.name %>
-					<%= navbar_item "Log Out", log_out_path %>
+					<%= navbar_item "Log Out", log_out_path, class: "hover-box-shadow" %>
 				<% else %>
 					<%= navbar_text "Not Logged In" %>
-					<%= navbar_item "Sign Up", new_user_path %>
+					<%= navbar_item "Sign Up", new_user_path, class: "hover-box-shadow" %>
 				<% end %>
 			<% end %>
 			</div>


### PR DESCRIPTION
This adds some shadows and indicators to the navbar to set it apart from the rest of the page and make it a bit more obvious. It mainly uses box-shadows. Note that if it isn't working there are `-moz-box-shadow` and `-webkit-box-shadow` rules which can be paralleled with `box-shadow` to do stuffies.

@cg505, how do you like it? I think it's pretty schmexy.
